### PR TITLE
Fixing divergance between old and new repos

### DIFF
--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -2,16 +2,16 @@ name: Sphinx docs to gh-pages
 
 on:
   push:
-    branches:
-      - master
-  pull_request:
-    types: [closed]
-    branches:
-      - master
+  #   branches:
+  #     - master
+  # pull_request:
+  #   types: [closed]
+  #   branches:
+  #     - master
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
-permissions:
-  contents: write
+# permissions:
+#   contents: write
 
 jobs:
   sphinx_docs_to_gh-pages:

--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - master
+  pull_request:
+    types: [closed]
+    branches:
+      - master
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
 permissions:
@@ -11,6 +15,7 @@ permissions:
 
 jobs:
   sphinx_docs_to_gh-pages:
+    if: github.event_name == 'push' || github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     name: Sphinx docs to gh-pages
     steps:

--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -6,6 +6,8 @@ on:
       - master
 
 # workflow_dispatch:        # Un comment line if you also want to trigger action manually
+permissions:
+  contents: write
 
 jobs:
   sphinx_docs_to_gh-pages:

--- a/.github/workflows/sphinx_docs_to_gh_pages.yaml
+++ b/.github/workflows/sphinx_docs_to_gh_pages.yaml
@@ -2,6 +2,7 @@ name: Sphinx docs to gh-pages
 
 on:
   push:
+  workflow_dispatch:
   #   branches:
   #     - master
   # pull_request:
@@ -19,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Sphinx docs to gh-pages
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Make conda environment

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ exclude_patterns = ['_build', 'prolog.rst', 'epilog.rst', 'Thumbs.db', '.DS_Stor
 #
 html_theme = 'sphinx_book_theme'
 html_theme_options = {
-    "repository_url": "https://github.com/NSLS-II-BMM/BeamlineManual",
+    "repository_url": "https://github.com/NSLS2/bmm-beamline-manual",
     "use_edit_page_button": False,
     "use_issues_button": True,
     "use_repository_button": True,

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -14,9 +14,9 @@ Introduction to BMM
 
 BMM is NIST's :red:`B`\ eamline for :red:`M`\ aterials :red:`M`\ easurement.
 
-At the unix command line, type ``bsui`` to start the BlueSky user
+At the unix command line, type ``bsui`` to start the Bluesky user
 interface.  |bsui| is simply an `IPython shell <https://ipython.org/>`_
-with some customizations specific to BlueSky.  On top of that, there
+with some customizations specific to Bluesky.  On top of that, there
 are a number of customizations specific to BMM.
 
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -66,7 +66,7 @@ Essential links
 The user experience
 -------------------
 
-The Ipython/|bsui| prompt at BMM is modified to provide at-a-glance
+The IPython/|bsui| prompt at BMM is modified to provide at-a-glance
 information about the state of the beamline.
 
 .. _fig-prompt:

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -15,7 +15,7 @@ Introduction to BMM
 BMM is NIST's :red:`B`\ eamline for :red:`M`\ aterials :red:`M`\ easurement.
 
 At the unix command line, type ``bsui`` to start the BlueSky user
-interface.  |bsui| is simply an `Ipython shell <https://ipython.org/>`_
+interface.  |bsui| is simply an `IPython shell <https://ipython.org/>`_
 with some customizations specific to BlueSky.  On top of that, there
 are a number of customizations specific to BMM.
 


### PR DESCRIPTION
At @yxrmz 's suggestion, pushing changes from the NSLS2 fork back to NSLS-II.  We will then delete the fork and transfer the repo.  All of this is an attempt to fix the action which rebuilds the presentation version of the manual.